### PR TITLE
Support multiple types for extracted metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,10 @@
-0.3.0
+0.4.0
+=====
+
+* Support the case that an extracted metric can have multiple types. Example: The Sequence Length reported by FastQC can either be `151` (`int`) or `10-151` (`str`).
+
+
+0.3.1
 =====
 
 * Ensure all needed values are extracted from the Kraken report, set defaults when not present

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qc-parser"
-version = "0.3.1"
+version = "0.4.0"
 description = "Parses outputs of different QC tools and unifies them for the SMaHT portal"
 authors = ["Alexander Veit <alexander_veit@hms.harvard.edu>", "Michele Berselli <berselli.michele@gmail.com>"]
 license = "MIT"

--- a/src/metrics_to_extract.py
+++ b/src/metrics_to_extract.py
@@ -622,7 +622,7 @@ fastqc_metrics = {
         "key": "Sequence Length [FastQC]",
         "tooltip": "Length of sequences",
         "derived_from": "fastqc:sequence_length",
-        "type": int,
+        "type": [int, str],
     },
 }
 

--- a/tests/data/fastqc_summary_2.txt
+++ b/tests/data/fastqc_summary_2.txt
@@ -10,4 +10,4 @@ PASS	Sequence Duplication Levels	1418708.180681.227CTHLT3.1.1.fastq.gz
 PASS	Overrepresented sequences	1418708.180681.227CTHLT3.1.1.fastq.gz
 PASS	Adapter Content	1418708.180681.227CTHLT3.1.1.fastq.gz
 13476802	Total Sequences	.
-151	Sequence Length	.
+10-150	Sequence Length	.

--- a/tests/test_parseqc.py
+++ b/tests/test_parseqc.py
@@ -24,7 +24,45 @@ def test_fastqc():
     data = json.load(qc_file)
     qc_file.close()
 
-    assert len(data["qc_values"]) == 11
+    assert len(data["qc_values"]) == 13
+
+    seq_len = next(
+        item
+        for item in data["qc_values"]
+        if item["derived_from"] == "fastqc:sequence_length"
+    )
+    assert seq_len["value"] == 151
+
+    os.system(f"rm -f {qc_values} {metrics_zip}")
+
+
+def test_fastqc_2():
+    pv = platform.python_version()
+    fastqc_stats = "./tests/data/fastqc_summary_2.txt"
+    qc_values = f"tmp.fastqc2.qc_values.{pv}.json"
+    metrics_zip = f"tmp.fastqc2.metrics.{pv}.zip"
+    cmd = (
+        f"parse-qc -n 'FastQC2' "
+        f"--metrics fastqc {fastqc_stats} "
+        f"--output-zip {metrics_zip} "
+        f"--output-json {qc_values}"
+    )
+    os.system(cmd)
+
+    assert os.path.exists(qc_values) == True
+
+    qc_file = open(qc_values)
+    data = json.load(qc_file)
+    qc_file.close()
+
+    assert len(data["qc_values"]) == 13
+
+    seq_len = next(
+        item
+        for item in data["qc_values"]
+        if item["derived_from"] == "fastqc:sequence_length"
+    )
+    assert seq_len["value"] == '10-150'
 
     os.system(f"rm -f {qc_values} {metrics_zip}")
 


### PR DESCRIPTION
Support the case that an extracted metric can have multiple types. Example: The Sequence Length reported by FastQC can either be `151` (`int`) or `10-151` (`str`).