### PR TITLE
Set mosdepth total coverage metric to visible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.8.3
+=====
+
+* Set mosdepth total coverage metric to visible
+
+
 0.7.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qc-parser"
-version = "0.8.2"
+version = "0.8.3"
 description = "Parses outputs of different QC tools and unifies them for the SMaHT portal"
 authors = ["Alexander Veit <alexander_veit@hms.harvard.edu>", "Michele Berselli <berselli.michele@gmail.com>"]
 license = "MIT"

--- a/src/metrics_to_extract.py
+++ b/src/metrics_to_extract.py
@@ -236,7 +236,6 @@ bamstats_metrics = {
         "tooltip": "Estimated average coverage",
         "derived_from": "bamstats:estimate_average_coverage",
         "type": float,
-        "visible": True,
     },
     "Total_Number_Of_Reads": {
         "key": "Total Number of Reads [bamstats]",
@@ -747,6 +746,7 @@ mosdepth_metrics = {
         "tooltip": "Estimated average coverage",
         "derived_from": "mosdepth:total",
         "type": float,
+        "visible": True,
     },
 }
 


### PR DESCRIPTION
Marked the mosdepth total coverage metric as visible in metrics_to_extract.py. Updated the version to 0.8.3 in pyproject.toml and added a corresponding entry in the changelog.